### PR TITLE
add codeowners and update branch references master -> main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Github CODEOWNERS file
+
+# Global code-owners for this repository
+*       @mattdean-digicatapult @digigarlab @chris-digicat

--- a/resources/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/resources/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,14 +5,14 @@ about: Create a report to help us improve
 
 <!--
 
-Have you read {project_name}'s Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/{project_module_name}/.github/blob/master/CODE_OF_CONDUCT.md
+Have you read {project_name}'s Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/{project_module_name}/.github/blob/main/CODE_OF_CONDUCT.md
 
 -->
 
 ### Prerequisites
 
 - [ ] Put an X between the brackets on this line if you have done all of the following:
-  - Checked the FAQs for common solutions: <https://github.com/digicatapult/{project_module_name}/blob/master/CONTRIBUTING.md/#FAQs>
+  - Checked the FAQs for common solutions: <https://github.com/digicatapult/{project_module_name}/blob/main/CONTRIBUTING.md/#FAQs>
   - Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3A{project_module_name}>
 
 ### Description

--- a/resources/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/resources/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ about: Suggest an idea for this project
 
 <!--
 
-Have you read {project_name}'s Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/{project_module_name}/.github/blob/master/CODE_OF_CONDUCT.md
+Have you read {project_name}'s Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/{project_module_name}/.github/blob/main/CODE_OF_CONDUCT.md
 
 ---
 Also note that the Digital Catapult team has finite resources so it's unlikely that we'll work on feature requests. If we're interested in a particular feature however, we'll follow up and ask you to submit an RFC to talk about it in more detail.

--- a/resources/.github/PULL_REQUEST_TEMPLATE.md
+++ b/resources/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 1. Copy the correct template for your contribution
 
-   - 🐛 Are you fixing a bug? Copy the template from <https://github.com/digicatapult/{project_module_name}/blob/master/.github/ISSUE_TEMPLATE/bug_report.md>
-   - 💻 Are you changing functionality? Copy the template from <https://github.com/digicatapult/{project_module_name}/blob/master/.github/ISSUE_TEMPLATE/feature_request.md>
+   - 🐛 Are you fixing a bug? Copy the template from <https://github.com/digicatapult/{project_module_name}/blob/main/.github/ISSUE_TEMPLATE/bug_report.md>
+   - 💻 Are you changing functionality? Copy the template from <https://github.com/digicatapult/{project_module_name}/blob/main/.github/ISSUE_TEMPLATE/feature_request.md>
 
 2. Replace this text with the contents of the template
 3. Fill in all sections of the template

--- a/resources/CONTRIBUTING.md
+++ b/resources/CONTRIBUTING.md
@@ -39,7 +39,7 @@ We don't have any frequently asked questions yet.
 
 This section guides you through submitting a bug report for {project_module_name}. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
 
-Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/digicatapult/{project_module_name}/blob/master/.github/ISSUE_TEMPLATE/bug_report.md), the information it asks for helps us resolve issues faster.
+Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/digicatapult/{project_module_name}/blob/main/.github/ISSUE_TEMPLATE/bug_report.md), the information it asks for helps us resolve issues faster.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
@@ -49,7 +49,7 @@ Before creating bug reports, please check [this list](#before-submitting-a-bug-r
 
 #### How Do I Submit A (Good) Bug Report?
 
-Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue on that repository and provide the following information by filling in [the template](https://github.com/digicatapult/{project_module_name}/.github/blob/master/.github/ISSUE_TEMPLATE/bug_report.md).
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue on that repository and provide the following information by filling in [the template](https://github.com/digicatapult/{project_module_name}/.github/blob/main/.github/ISSUE_TEMPLATE/bug_report.md).
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
@@ -78,7 +78,7 @@ Include details about your configuration and environment:
 
 This section guides you through submitting an enhancement suggestion for {project_module_name}, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
-Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/digicatapult/{project_module_name}/blob/master/.github/ISSUE_TEMPLATE/feature_request.md), including the steps that you imagine you would take if the feature you're requesting existed.
+Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/digicatapult/{project_module_name}/blob/main/.github/ISSUE_TEMPLATE/feature_request.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
 #### Before Submitting An Enhancement Suggestion
 


### PR DESCRIPTION
Added the committee as `CODEOWNERS` for this repo and fixed an issue found by @hassan-digicatapult where the branch references still refered to `master` in some links