### PR TITLE
Workflow templates for synchronising npm version to trunk for pull requests

### DIFF
--- a/workflow-templates/synchronise-pr-version-npm.json
+++ b/workflow-templates/synchronise-pr-version-npm.json
@@ -1,0 +1,7 @@
+{
+  "name": "Synchronise Pull-Request Version (npm)",
+  "description": "Synchronises the npm version in a package.json against the trunk branch given a label applied to the pull-request",
+  "iconName": "octicon hash",
+  "categories": ["JavaScript", "TypeScript"],
+  "filePatterns": ["^package.json$"]
+}

--- a/workflow-templates/synchronise-pr-version-npm.yml
+++ b/workflow-templates/synchronise-pr-version-npm.yml
@@ -1,0 +1,16 @@
+name: Synchronise Version
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  synchronise-trunk-version-npm:
+    uses: digicatapult/shared-workflows/.github/workflows/synchronise-pr-version-npm.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+      trunk-branch: $default-branch

--- a/workflow-templates/synchronise-pr-version-npm.yml
+++ b/workflow-templates/synchronise-pr-version-npm.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  synchronise-trunk-version-npm:
+  synchronise-pr-version-npm:
     uses: digicatapult/shared-workflows/.github/workflows/synchronise-pr-version-npm.yml@main
     with:
       pr-number: ${{ github.event.pull_request.number }}

--- a/workflow-templates/synchronise-trunk-version-npm.json
+++ b/workflow-templates/synchronise-trunk-version-npm.json
@@ -1,0 +1,7 @@
+{
+  "name": "Synchronise all PR versions to trunk (npm)",
+  "description": "Synchronises the npm version in a package.json for all pull-requests on change to the default branch",
+  "iconName": "octicon hash",
+  "categories": ["JavaScript", "TypeScript"],
+  "filePatterns": ["^package.json$"]
+}

--- a/workflow-templates/synchronise-trunk-version-npm.yml
+++ b/workflow-templates/synchronise-trunk-version-npm.yml
@@ -1,0 +1,15 @@
+name: Synchronise all PR versions
+
+on:
+  push:
+    branches: $default-branch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  synchronise-trunk-version-npm:
+    uses: digicatapult/shared-workflows/.github/workflows/synchronise-trunk-version-npm.yml@main
+    with:
+      trunk-branch: $default-branch


### PR DESCRIPTION
Workflow templates for synchronising npm version to trunk for pull requests

# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

[ENG-72](https://digicatapult.atlassian.net/browse/ENG-72)

## High level description

Adds workflow templates for synchronising pull request versions.

## Detailed description

Adds two workflow templates:

1. `synchronise-pr-version-npm` calls `synchronise-pr-version-npm` in https://github.com/digicatapult/shared-workflows. Is executed on default PR activities and also when adding/removing labels
2. `synchronise-trunk-version-npm` calls `synchronise-trunk-version-npm` in https://github.com/digicatapult/shared-workflows. Is executed on push to the default branch

See https://github.com/digicatapult/shared-workflows/pull/1 for a descritpion of what these do (documentation is coming once this all works)

## Describe alternatives you've considered

None

## Operational impact

None

## Additional context

None


[ENG-72]: https://digicatapult.atlassian.net/browse/ENG-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ